### PR TITLE
Release for v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.0.9](https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.0.8...v0.0.9) - 2024-01-06
+- Update readme by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/16
+- labeler is useful by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/18
+- Update actions/setup-go action to v5 by @renovate in https://github.com/chaspy/gh-monorepo-pr-count/pull/21
+- Auto merge setting by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/22
+- Rename tool name by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/23
+
 ## [v0.0.8](https://github.com/chaspy/gh-pr-count/compare/v0.0.7...v0.0.8) - 2023-11-26
 - Parallel by @chaspy in https://github.com/chaspy/gh-pr-count/pull/14
 


### PR DESCRIPTION
This pull request is for the next release as v0.0.9 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.9 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.8" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Update readme by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/16
* labeler is useful by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/18
* Update actions/setup-go action to v5 by @renovate in https://github.com/chaspy/gh-monorepo-pr-count/pull/21
* Auto merge setting by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/22
* Rename tool name by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/23


**Full Changelog**: https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.0.8...v0.0.9