### PR TITLE
Release for v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.1.1](https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.1.0...v0.1.1) - 2024-01-07
+- Support uniq author by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/24
+- Update dependency go to v1.21.5 by @renovate in https://github.com/chaspy/gh-monorepo-pr-count/pull/20
+
 ## [v0.0.9](https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.0.8...v0.0.9) - 2024-01-06
 - Update readme by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/16
 - labeler is useful by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/18


### PR DESCRIPTION
This pull request is for the next release as v0.1.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Support uniq author by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/24
* Update dependency go to v1.21.5 by @renovate in https://github.com/chaspy/gh-monorepo-pr-count/pull/20


**Full Changelog**: https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.1.0...v0.1.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 各著者に対するサポートを追加。
- **依存関係の更新**
  - `go`をバージョン`v1.21.5`に更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->