### PR TITLE
Release for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.3.1](https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.3.0...v0.3.1) - 2024-01-07
+- Refactoring: Improve walk function by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/28
+- Update go and tool version in workflow files by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/30
+- Tweak renovate config by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/31
+- fix typo by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/32
+- Fix renovate datasource and tweak regex by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/33
+- Fix depNameTemplate and versioningTemplate by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/34
+- Update dependency golang-version to v1.21.5 by @renovate in https://github.com/chaspy/gh-monorepo-pr-count/pull/35
+
 ## [v0.3.0](https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.2.0...v0.2.1) - 2024-01-07
 
 - Support debug url flag by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/26


### PR DESCRIPTION
This pull request is for the next release as v0.3.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Refactoring: Improve walk function by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/28
* Update go and tool version in workflow files by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/30
* Tweak renovate config by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/31
* fix typo by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/32
* Fix renovate datasource and tweak regex by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/33
* Fix depNameTemplate and versioningTemplate by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/34
* Update dependency golang-version to v1.21.5 by @renovate in https://github.com/chaspy/gh-monorepo-pr-count/pull/35


**Full Changelog**: https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.3.0...v0.3.1