### PR TITLE
Release for v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.3.2](https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.3.1...v0.3.2) - 2024-01-22
+- Update dependency go to v1.21.6 by @renovate in https://github.com/chaspy/gh-monorepo-pr-count/pull/36
+- Auto merge golang-version by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/39
+- Update dependency golang-version to v1.21.6 by @renovate in https://github.com/chaspy/gh-monorepo-pr-count/pull/40
+- ci: Add path filter for pull_request event by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/41
+
 ## [v0.3.1](https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.3.0...v0.3.1) - 2024-01-07
 - Refactoring: Improve walk function by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/28
 - Update go and tool version in workflow files by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/30


### PR DESCRIPTION
This pull request is for the next release as v0.3.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Update dependency go to v1.21.6 by @renovate in https://github.com/chaspy/gh-monorepo-pr-count/pull/36
* Auto merge golang-version by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/39
* Update dependency golang-version to v1.21.6 by @renovate in https://github.com/chaspy/gh-monorepo-pr-count/pull/40
* ci: Add path filter for pull_request event by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/41


**Full Changelog**: https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.3.1...v0.3.2