### PR TITLE
Support open/closed state to search PRs

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,12 +26,17 @@ func usage() {
 	fmt.Println("example: gh monorepo-pr-count 2023-10-01 2023-11-01 // Search PRs merged since 2023-10-01 until 2023-11-01")
 }
 
-func makeMergedQuery(since string, until string) string {
+func makeStateQuery(state string, since string, until string) string {
 	var mergedQuery string
+
+	if state == "open" {
+		state = "created"
+	}
+
 	if until != "" {
-		mergedQuery = "merged:" + since + ".." + until
+		mergedQuery = state + ":" + since + ".." + until
 	} else {
-		mergedQuery = "merged:>=" + since
+		mergedQuery = state + ":>=" + since
 	}
 	return mergedQuery
 }
@@ -178,6 +183,9 @@ func run() error {
 
 	sinceFlag := flag.String("since", "", "Required: Search PRs merged since this date. Format: yyyy-mm-dd")
 	untilFlag := flag.String("until", today, "Optional: Search PRs merged until this date. Format: yyyy-mm-dd")
+
+	stateFlag := flag.String("state", "merged", "Optional: Search PRs with the specified state(open|closed|merged). Default: merged")
+
 	flag.Parse()
 
 	// sinceFlag is required
@@ -186,11 +194,11 @@ func run() error {
 		os.Exit(1)
 	}
 
-	mergedQuery := makeMergedQuery(*sinceFlag, *untilFlag)
+	stateQuery := makeStateQuery(*stateFlag, *sinceFlag, *untilFlag)
 
 	// Add $SEARCH_QUERY from environment variable
 	additionalSearchQuery := os.Getenv("SEARCH_QUERY")
-	searchQuery := mergedQuery + " " + additionalSearchQuery
+	searchQuery := stateQuery + " " + additionalSearchQuery
 
 	targetRepo, err := getTargetRepo()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -27,18 +27,21 @@ func usage() {
 }
 
 func makeStateQuery(state string, since string, until string) string {
-	var mergedQuery string
+	var stateQuery string
+	var queryState string
 
 	if state == "open" {
-		state = "created"
+		queryState = "created"
+	} else {
+		queryState = state
 	}
 
 	if until != "" {
-		mergedQuery = state + ":" + since + ".." + until
+		stateQuery = "is:" + state + " " + queryState + ":" + since + ".." + until
 	} else {
-		mergedQuery = state + ":>=" + since
+		stateQuery = "is:" + state + " " + queryState + ":>=" + since
 	}
-	return mergedQuery
+	return stateQuery
 }
 
 func getTargetRepo() (string, error) {


### PR DESCRIPTION
…improve semantics and add support for searching PRs with different states (open, closed, merged)

✨ feat(main.go): add support for stateFlag command-line flag to specify the state of PRs to search (open, closed, merged). Default state is merged.

これまでは merge された PR を count したかったが、merged 以外にも open, closed をサポート。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- PRの状態（"open"、"created"など）を指定して検索できるように、クエリ構築機能を改善しました。デフォルトは"merged"です。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->