### PR TITLE
Release for v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.4.4](https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.4.3...v0.4.4) - 2024-03-11
+- Revert "Update go" by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/55
+
 ## [v0.4.3](https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.4.2...v0.4.3) - 2024-03-11
 - Support .github dir by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/52
 - Update usage for help by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/54


### PR DESCRIPTION
This pull request is for the next release as v0.4.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.4.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.4.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Revert "Update go" by @chaspy in https://github.com/chaspy/gh-monorepo-pr-count/pull/55


**Full Changelog**: https://github.com/chaspy/gh-monorepo-pr-count/compare/v0.4.3...v0.4.4